### PR TITLE
add Custom message to check response struct

### DIFF
--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -21,6 +21,7 @@ type PingdomError struct {
 type CheckResponse struct {
 	ID                       int                 `json:"id"`
 	Name                     string              `json:"name"`
+	CustomMessage            string              `json:"custom_message,omitempty"`
 	Resolution               int                 `json:"resolution,omitempty"`
 	SendNotificationWhenDown int                 `json:"sendnotificationwhendown,omitempty"`
 	NotifyAgainEvery         int                 `json:"notifyagainevery,omitempty"`

--- a/pingdom/api_responses_test.go
+++ b/pingdom/api_responses_test.go
@@ -177,3 +177,44 @@ func TestCheckContactUnmarshal(t *testing.T) {
 	assert.NotNil(t, contact.ID)
 	assert.Equal(t, expectedNotificationTargets, contact.NotificationTargets)
 }
+
+var detailedCustomMessageCheckJSON = `
+{
+	"id" : 85975,
+	"name" : "My check 7",
+  "custom_message": "I am the Walrus",
+	"resolution" : 1,
+	"sendnotificationwhendown" : 0,
+	"notifyagainevery" : 0,
+	"notifywhenbackup" : false,
+	"created" : 1240394682,
+	"type" : {
+		"http" : {
+			"url" : "/",
+			"port" : 80,
+			"requestheaders" : {
+				"User-Agent" : "Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+				"Prama" : "no-cache"
+			}
+		}
+	},
+	"hostname" : "s7.mydomain.com",
+	"status" : "up",
+	"severity_level": "HIGH",
+	"lasterrortime" : 1293143467,
+	"lasttesttime" : 1294064823,
+	"tags": [],
+	"responsetime_threshold": 2300
+}
+`
+
+func TestCustomMessageCheckResponseUnmarshal(t *testing.T) {
+	var ck CheckResponse
+	err := json.Unmarshal([]byte(detailedCustomMessageCheckJSON), &ck)
+	assert.NoError(t, err)
+	assert.Equal(t, "http", ck.Type.Name)
+	assert.NotNil(t, ck.Type.HTTP)
+	assert.Equal(t, 2, len(ck.Type.HTTP.RequestHeaders))
+	assert.Equal(t, "HIGH", ck.SeverityLevel)
+	assert.Equal(t, "I am the Walrus", ck.CustomMessage)
+}

--- a/pingdom/doc.go
+++ b/pingdom/doc.go
@@ -12,7 +12,7 @@ Construct a new Pingdom client:
 
 Using a Pingdom client, you can access supported services.
 
-CheckService
+# CheckService
 
 This service manages pingdom Checks which are represented by the `Check` struct.
 When creating or updating Checks you must specify at a minimum the `Name`, `Hostname`
@@ -56,6 +56,5 @@ Update a check:
 Delete a check:
 
 	msg, err := client.Checks.Delete(12345)
-
 */
 package pingdom


### PR DESCRIPTION
Hey! I want to use your fork, since you've included the custom message property in the HttpCheck type - however, I also need to access that property on the CheckResponse type. 

Let me know if you've got any questions about this, or if you don't want to accept the change - in that case I can publish my own fork :) 